### PR TITLE
Convenient way to add, remove and update libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ android.library.reference.8=../google-play-services-ads-lite
 
 ```
 
+###Adding more dependencies
+
+If you need to add more dependencies, you can run `./select_dependencies.sh` and select the needed google play services libraries from the list. These will become available afterwards as per above method.
+
+###Updating dependencies
+
+If you need to update the libraries, simply run `./update_dependencies.sh`
+
 ###Disclaimer
 
 Google is a registered trademark of Google Inc.

--- a/select_dependencies.sh
+++ b/select_dependencies.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+: ${ANDROID_SDK?"No ANDROID_SDK environment variable set. You can set it first with e.g. : export ANDROID_SDK=~/SDKs/android-sdk/"}
+
+GMSPATH=$ANDROID_SDK"/extras/google/m2repository/com/google/android/gms/*"
+DEPPATH="./dependencies/"
+
+GMSFILES=()
+GMSSELECTED=()
+GMSPRESELECTED=("google-play-services-basement" "google-play-services-ads-lite" "google-play-services-auth" "google-play-services-base" "google-play-services-drive" "google-play-services-plus" "google-play-services-games" "google-play-services-gcm" "google-play-services-iid")
+
+
+
+select_dependencies () {
+
+  for f in $DEPPATH*
+  do
+     if [[ -d $f ]]; then GMSPRESELECTED+=("$(basename $f)"); fi;
+  done
+
+  # cycle through each gms dir
+  a=0;
+  for f in $GMSPATH
+  do
+     a=$((a+1));
+     PACKAGENAME=$(basename $f)
+     GMSFILES+=($PACKAGENAME)
+
+     GMSSELECTED[$a]="*"
+     if [[ " ${GMSPRESELECTED[@]} " =~ " google-${PACKAGENAME} " ]]; then
+         GMSSELECTED[$a]="*"
+     else
+         GMSSELECTED[$a]=" "
+     fi
+     
+  done
+
+
+  while :
+  do
+      clear
+    cat<<EOF
+
+    ==============================
+    Play Services Builder
+    ------------------------------
+    Select which services you'd like included:
+
+EOF
+  a=0;
+  selected=0;
+  for i in "${GMSFILES[@]}"
+  do
+     a=$((a+1));
+     if  (($a < 10))
+        then
+           echo "     ["${GMSSELECTED[$a]}"0$a] google-"$i" "
+     else
+           echo "     ["${GMSSELECTED[$a]}"$a] google-"$i" "
+     fi
+     if  [[ "${GMSSELECTED[$a]}" == "*" ]]; then selected=$((selected+1)) ; fi
+  done
+cat<<EOF
+
+     [ **] Select all
+     [ CO] Continue
+     [ QQ] Quit
+
+    ------------------------------
+    $selected Packages selected
+
+    Select option or press [Enter] to continue
+EOF
+      read -n2
+
+  a=0;
+  for i in "${GMSFILES[@]}"
+  do
+     a=$((a+1));
+     if [[ "$REPLY" == "$a" || "$REPLY" == "0$a" ]]; then
+
+        if [ "${GMSSELECTED[$a]}" == "*" ]; then
+           GMSSELECTED[$a]=" " ; REPLY="unselected"
+        elif [ "${GMSSELECTED[$a]}" == " " ]; then
+           GMSSELECTED[$a]="*" ; REPLY="selected"
+        fi 
+        
+     fi
+
+     if [[ "$REPLY" == "a" || "$REPLY" == "**" || "$REPLY" == "*" || "$REPLY" == "A" || "$REPLY" == "al" || "$REPLY" == "AL" ]]; then
+        GMSSELECTED[$a]="*" ;
+     fi
+  done
+
+  if [[ "$REPLY" == "a" || "$REPLY" == "**" || "$REPLY" == "*" || "$REPLY" == "A" || "$REPLY" == "al" || "$REPLY" == "AL" ]]; then
+     REPLY="selected"
+  fi
+
+      case "$REPLY" in
+        "selected")  echo "selected" ;;
+        "unselected")  echo "unselected" ;;
+        "")  update_dependencies ;;
+        " ")  update_dependencies  ;;
+        "CO")  update_dependencies                      ;;
+        "co")  update_dependencies                      ;;
+        "QQ")  echo "aborted"; exit                      ;;
+        "qq")  echo "aborted"; exit   ;; 
+        * )  echo "'"$REPLY"' is an invalid option"     ;;
+      esac
+      if [[ "$REPLY" != "selected" && "$REPLY" != "unselected" ]]; then sleep 1; fi
+  done
+}
+
+
+update_dependencies () {
+  PACKAGES=""
+  a=0;
+  for i in "${GMSFILES[@]}"
+  do
+     a=$((a+1));
+     if [ "${GMSSELECTED[$a]}" == "*" ]; then
+      PACKAGES=$PACKAGES" google-$i"
+     fi
+  done
+  #echo $PACKAGES
+  ./update_dependencies.sh $PACKAGES
+  exit
+} 
+
+select_dependencies

--- a/template/build.xml
+++ b/template/build.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="admobex" default="help">
+        <property environment="env"/>
+        <property name="sdk.dir" value="${env.ANDROID_SDK}"/>
+		<property file="project.properties" />
+		<import file="${sdk.dir}/tools/ant/build.xml"/>
+</project>

--- a/template/build.xml
+++ b/template/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="admobex" default="help">
+<project name="::APP_FILE::" default="help">
         <property environment="env"/>
         <property name="sdk.dir" value="${env.ANDROID_SDK}"/>
 		<property file="project.properties" />

--- a/template/project.properties
+++ b/template/project.properties
@@ -1,0 +1,7 @@
+android.library=true
+target=android-::ANDROID_TARGET_SDK_VERSION::
+
+manifestmerger.enabled = true
+
+java.source=1.7
+java.target=1.7

--- a/update_dependencies.sh
+++ b/update_dependencies.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+: ${ANDROID_SDK?"No ANDROID_SDK environment variable set. You can set it first with e.g. : export ANDROID_SDK=~/SDKs/android-sdk/"}
+
+GMSPATH=$ANDROID_SDK"/extras/google/m2repository/com/google/android/gms/*"
+DEPPATH="./dependencies/"
+LIMITTO=()
+
+
+if [[ $@ ]]
+    then
+        LIMITTO=( "$@" )
+        for arg in "$@"
+        do
+            LIMITTO+=("$arg")
+        done
+        echo "Updating selected dependencies"
+else
+    for f in $DEPPATH*/
+    do
+        if [[ -d $f ]]; then LIMITTO+=("$(basename $f)"); fi;
+    done
+    if [[ -z "$LIMITTO" ]]; then echo "No dependencies found, run ./select_dependencies.sh instead"; exit;
+    else echo "Updating existing dependencies"
+    fi
+fi
+
+
+# clear old version
+echo "Clearing dependencies"
+rm -rf $DEPPATH*
+
+# cycle through each gms dir
+for f in $GMSPATH
+do
+    PACKAGENAME="google-"$(basename $f)
+    HIGH_VER=`ls -d -v $f/*/ | tail -n 1`
+    VERNUM="$(basename $HIGH_VER)"
+    if [[ " ${LIMITTO[@]} " =~ " ${PACKAGENAME} " ]]; then
+        echo "Adding $PACKAGENAME ($VERNUM)"
+        AAR=`find $HIGH_VER -iname '*.aar' | sed s#//*#/#g`
+        cp $AAR $DEPPATH"google-"$(basename $AAR)
+        FILENAME=$DEPPATH"google-"$(basename $AAR)
+        OUTDIR=$(echo ${FILENAME%.*})
+        OUTDIR=${OUTDIR%-$VERNUM}
+
+        #extract .aar file and delete it
+        unzip -q $FILENAME -d $OUTDIR
+        rm $FILENAME
+
+        mkdir -p $OUTDIR/libs
+        mkdir -p $OUTDIR/src
+        mkdir -p $OUTDIR/res
+
+        # if classes.jar exists move inside libs/ directory
+    	if [ -f $OUTDIR/classes.jar ]; then
+    	    mv $OUTDIR/classes.jar $OUTDIR/libs/classes.jar
+    	fi
+
+        ## remove proguard.txt (?)
+        ## add build.xml
+        cp template/build.xml $OUTDIR/build.xml
+        ## add project.properties
+        cp template/project.properties $OUTDIR/project.properties
+    fi
+done
+
+echo "Writing include.xml"
+cat << EOF > ./include.xml
+<?xml version="1.0" encoding="utf-8"?>
+<extension>
+    <section if="android">
+EOF
+for f in $DEPPATH*/
+do
+    f=$(basename $f)
+cat << EOF >> ./include.xml
+        <dependency name="$f"
+            path="dependencies/$f"
+            if="$f" />
+EOF
+done
+cat << EOF >> ./include.xml
+    </section>
+</extension>
+EOF
+
+echo "Done"


### PR DESCRIPTION
We needed to add more libraries, e.g. the `google-play-services-analytics-impl` for this to work with the GAnalytics repo, so decided to add 2 convenient scripts instead : 
- `select_dependencies.sh` let's you quickly select from a list which dependencies you'd like to add/remove
- `update_dependencies.sh` updates all current dependencies to their latest versions

After all dependencies have been copied, the `include.xml` is rewritten to reflect the new available dependencies.
